### PR TITLE
Build Linux binaries in Debian 11 container for glibc 2.31 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           - os: macos-14
             arch: x64
     runs-on: ${{ matrix.os }}
+    container: ${{ contains(matrix.os, 'ubuntu') && 'debian:bullseye' || '' }}
     defaults:
       run:
         shell: bash
@@ -44,8 +45,9 @@ jobs:
           key: nvm-windows
       - if: ${{ runner.os == 'Linux' }}
         run: |
+          apt-get update && apt-get install -y python3 make g++ git libxinerama-dev libxtst-dev curl
           echo NVM_DIR=$HOME/.nvm >>$GITHUB_ENV
-          sudo apt-get install libxinerama-dev libxtst-dev
+          curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
       - if: ${{ runner.os == 'macOS' }}
         run: |
           echo NVM_DIR=$HOME/.nvm >>$GITHUB_ENV


### PR DESCRIPTION
The ubuntu-22.04 runner has glibc 2.34, which makes the built binaries
incompatible with older systems like Debian 11 (glibc 2.31). By building
inside a debian:bullseye container, the native addon only links against
glibc 2.31 symbols, restoring backward compatibility.

https://claude.ai/code/session_01H1QkP5FvMfY9sBiuiMeRv4